### PR TITLE
Set default auth and dashboard routes

### DIFF
--- a/apps/dashboard/src/pages/auth/shell/AuthShell.page.tsx
+++ b/apps/dashboard/src/pages/auth/shell/AuthShell.page.tsx
@@ -15,6 +15,12 @@ export const AuthShellPage: React.FC<IAuthShellPageProps> = () => {
   return (
     <div>
       hello world from auth page
+      <Routes>
+        <Route path="/" element={<Navigate to="login" />} />
+        <Route path="login" element={<LoginPage />} />
+        <Route path="signup" element={<SignUpPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+      </Routes>
     </div>
   )
 }

--- a/apps/dashboard/src/pages/entry-routes/EntryRoutes.page.tsx
+++ b/apps/dashboard/src/pages/entry-routes/EntryRoutes.page.tsx
@@ -19,11 +19,9 @@ export const EntryRoutesPage: React.FC<IEntryRoutesPageProps> = () => {
     <>
     <span>Entry page</span>
     <Routes>
-      <Route path="auth" element={<AuthShellPage />} >
-        <Route path="login" element={<LoginPage />} />
-        <Route path="login" element={<LoginPage />} />
-      </Route>
-      <Route path="dashboard" element={<DashboardShellPage />} />
+      <Route path="/" element={<Navigate to="auth" />} />
+      <Route path="auth/*" element={<AuthShellPage />} />
+      <Route path="dashboard/*" element={<DashboardShellPage />} />
     </Routes >
     </>
   )


### PR DESCRIPTION
1. Create EntryRoutes to control all routes of the dashboard.
2. Set global auth and dashboard routes
3. Add "*" to "auth" and "dashboard" path  to reach nested routes.
4. Separate auth routes and dashboard routes in AuthShell page and Dashboard page respectively.
5. Set redirecting within url.